### PR TITLE
Deploy heroku button

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 | [![Build Status][build-image]][build-url] | ![python 3.6][python36] |
 | [![PyPI Version][pypi-image]][pypi-url] | ![django 1.11][django111] |
 | [![Code Climate](https://api.codeclimate.com/v1/badges/eed2b78a9c9cbf80e7af/maintainability)](https://codeclimate.com/github/project-callisto/callisto-core/maintainability) | - |
-| [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/new?template=https://github.com/project-callisto/callisto-core/) | - |
+| [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/new?template=https://github.com/project-callisto/callisto-core/&env\[DJANGO_SETTINGS_MODULE\]=callisto_core.utils.settings_live) | - |
 
 [build-image]: https://travis-ci.org/project-callisto/callisto-core.svg?branch=master
 [build-url]: https://travis-ci.org/project-callisto/callisto-core

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 | [![Build Status][build-image]][build-url] | ![python 3.6][python36] |
 | [![PyPI Version][pypi-image]][pypi-url] | ![django 1.11][django111] |
 | [![Code Climate](https://api.codeclimate.com/v1/badges/eed2b78a9c9cbf80e7af/maintainability)](https://codeclimate.com/github/project-callisto/callisto-core/maintainability) | - |
+| [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/new?template=https://github.com/project-callisto/callisto-core/) | - |
 
 [build-image]: https://travis-ci.org/project-callisto/callisto-core.svg?branch=master
 [build-url]: https://travis-ci.org/project-callisto/callisto-core


### PR DESCRIPTION
Adding a Deploy to heroku button to the Readme. #268 

Also, supplied a default value for DJANGO_SETTINGS_MODULE in the button since a new user might be know what this is. Thought that "callisto_core.utils.settings_live" was a sensible default because of [here](https://pypkg.com/pypi/callisto-core/f/callisto_core/utils/wsgi.py).



