### PR TITLE
prepend DEBUG to email subjects if in debug mode

### DIFF
--- a/callisto_core/notification/api.py
+++ b/callisto_core/notification/api.py
@@ -67,9 +67,11 @@ class CallistoCoreNotificationApi(object):
     def in_demo_mode(self):
         return self.context.get('DEMO_MODE', False)
 
-    def prepend_subject_if_demo_mode(self, subject):
+    def prepend_subject_if_demo_debug_mode(self, subject):
         if self.in_demo_mode:
             return f'[DEMO] {subject}'
+        elif settings.DEBUG:
+            return f'[DEBUG] {subject}'
         else:
             return subject
 
@@ -398,18 +400,18 @@ class CallistoCoreNotificationApi(object):
                 self.context['email_template_name']).template.source
             self.context.update({
                 'notification_name': self.context['email_template_name'],
-                'subject': self.prepend_subject_if_demo_mode(self.context['email_subject']),
+                'subject': self.prepend_subject_if_demo_debug_mode(self.context['email_subject']),
                 'body': body,
             })
         elif len(self.models_on_site) == 1:
             notification = self.models_on_site[0]
             self.context.update({
-                'subject': self.prepend_subject_if_demo_mode(notification.subject),
+                'subject': self.prepend_subject_if_demo_debug_mode(notification.subject),
                 'body': notification.body,
             })
         else:
             self.context.update({
-                'subject': self.prepend_subject_if_demo_mode(self.context['notification_name']),
+                'subject': self.prepend_subject_if_demo_debug_mode(self.context['notification_name']),
                 'body': self.context['notification_name'],
             })
 

--- a/callisto_core/tests/reporting/test_demo_mode.py
+++ b/callisto_core/tests/reporting/test_demo_mode.py
@@ -1,6 +1,7 @@
 from unittest.mock import call, patch
 
 from django.contrib.sites.models import Site
+from django.test import override_settings
 
 from callisto_core.reporting.views import ReportingConfirmationView
 from callisto_core.tests.test_base import (
@@ -13,7 +14,7 @@ from callisto_core.utils.sites import TempSiteID
 class DemoModeNotificationSubjectTest(
     ReportFlowTestCase,
 ):
-
+    
     def test_default(self):
         with patch.object(CustomNotificationApi, '_logging') as api_logging:
             self.client_post_report_creation()
@@ -35,6 +36,15 @@ class DemoModeNotificationSubjectTest(
             call(subject='[DEMO] report_delivery'),
         ], any_order=True)
 
+    @override_settings(DEBUG=True)
+    def test_debug_mode(self):
+        with patch.object(CustomNotificationApi, '_logging') as api_logging:
+            self.client_post_report_creation()
+            self.client_post_reporting_end_step()
+
+        api_logging.assert_has_calls([
+            call(subject='[DEBUG] report_delivery'),
+        ], any_order=True)
 
 class DemoModeNotificationNameTest(
     ReportFlowTestCase,


### PR DESCRIPTION
This closes https://github.com/project-callisto/callisto-core/issues/402 by prepending `DEBUG` on subjects if `settings.DEBUG=true` 

I did notice there was a `DEMO` prepend added after the above issue was created, but hopefully they are used for separate things and `DEBUG` is still useful.
