### PR TITLE
Removing a link to SHI instead of Project Callisto in Wizard builder template

### DIFF
--- a/callisto_core/wizard_builder/templates/wizard_builder/base.html
+++ b/callisto_core/wizard_builder/templates/wizard_builder/base.html
@@ -11,6 +11,6 @@
     <hr />
     {% block content %}{% endblock %}
 
-    <footer style="padding-top: 50px;">A <a href='https://github.com/SexualHealthInnovations'>SHI</a> project</footer>
+    <footer style="padding-top: 50px;">A <a href='https://github.com/project-callisto'>Callisto</a> Project</footer>
 
 </div></div></div></div>


### PR DESCRIPTION
Opportunity for a footer partial to be used in both 'delivery' templates and wizard builder templates. For now, updating the link. 