### PR TITLE
Change password reset form to work with encrypted usernames.

### DIFF
--- a/callisto_core/accounts/templates/callisto_core/accounts/password_reset_email.html
+++ b/callisto_core/accounts/templates/callisto_core/accounts/password_reset_email.html
@@ -1,4 +1,4 @@
-Hello {{ user.username }},
+Hello,
 <p>
 Someone requested that the password be reset for your Callisto account ({{ domain }}).
 </p>


### PR DESCRIPTION
### Summary
This diff updates the password reset system to work with the encrypted usernames/optional emails introduced in #444.

### Test Plan
**Running on my dev environment:**
![Screen Shot 2019-06-18 at 4 55 34 PM](https://user-images.githubusercontent.com/558471/59727333-1e67ba80-91ea-11e9-9910-f81e26fa1971.png)

This was in dev mode, so the email wasn't actually sent, but we can see that it selected the correct user to send the email to. No modification was needed to only use the email given by the user instead of pulling from the database, as Django already does that. To verify this, I cleared the email field on my user record, and did this test.